### PR TITLE
128 add default git directory

### DIFF
--- a/dockerHub/docker-compose.yml
+++ b/dockerHub/docker-compose.yml
@@ -1,5 +1,5 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-# Copyright 2025 Xyna GmbH, Germany
+# Copyright 2026 Xyna GmbH, Germany
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -58,6 +58,7 @@ services:
       - xyna-xnwhclasses:/opt/xyna/xyna_001/server/xnwhclasses
       - xyna-gen:/opt/xyna/xyna_001/server/gen
       - xyna-storage:/opt/xyna/xyna_001/server/storage
+      - xyna-git:/opt/xyna/xyna_001/git
     configs:
      - source: userarchive.XYNA.password
        target: /userarchive/${XYNAUSER_USERNAME}.password
@@ -152,4 +153,5 @@ volumes:
   xyna-xnwhclasses:
   xyna-gen:
   xyna-storage:
+  xyna-git:
   mariadb-mysql:

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-image.release.number=1.4.5
+image.release.number=1.4.6

--- a/xynadev/Dockerfile
+++ b/xynadev/Dockerfile
@@ -1,5 +1,5 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-# Copyright 2023 Xyna GmbH, Germany
+# Copyright 2026 Xyna GmbH, Germany
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -55,7 +55,8 @@ RUN ${XYNA_PATH}/server/xynafactory.sh start \
 
 
 # prepare revisions, server and xmomrepository folder - mount persistent volume on ${XYNA_PATH}
-RUN cp -r ${XYNA_PATH} ${XYNA_PATH}/../xyna_image
+RUN cp -r ${XYNA_PATH} ${XYNA_PATH}/../xyna_image \
+  && mkdir ${XYNA_PATH}/../git
 
 USER 4242:4242
 ENV HOSTNAME=xynaContainer

--- a/xynadev/Dockerfile
+++ b/xynadev/Dockerfile
@@ -56,7 +56,7 @@ RUN ${XYNA_PATH}/server/xynafactory.sh start \
 
 # prepare revisions, server and xmomrepository folder - mount persistent volume on ${XYNA_PATH}
 RUN cp -r ${XYNA_PATH} ${XYNA_PATH}/../xyna_image \
-  && mkdir ${XYNA_PATH}/../git
+  && mkdir ${XYNA_PATH}/git
 
 USER 4242:4242
 ENV HOSTNAME=xynaContainer

--- a/xynafactory/Dockerfile
+++ b/xynafactory/Dockerfile
@@ -1,5 +1,5 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-# Copyright 2024 Xyna GmbH, Germany
+# Copyright 2026 Xyna GmbH, Germany
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -84,6 +84,7 @@ ${XYNAFACTORY_SH} stop
 find /opt/xyna/xyna_001/storage -name "*.journal" | xargs --no-run-if-empty rm
 /k8s/xyna/xmomrepository_adjust_revision.sh ${XMOMREPOSITORY}
 /k8s/xyna/xmomrepository_adjust_revision_history.sh ${XMOMREPOSITORY}
+mkdir ${XYNA_PATH}/../git
 EOF
 
 ENV SYNC_CONTAINER_LIFECYCLE_TO_FACTORY=true

--- a/xynafactory/Dockerfile
+++ b/xynafactory/Dockerfile
@@ -84,7 +84,7 @@ ${XYNAFACTORY_SH} stop
 find /opt/xyna/xyna_001/storage -name "*.journal" | xargs --no-run-if-empty rm
 /k8s/xyna/xmomrepository_adjust_revision.sh ${XMOMREPOSITORY}
 /k8s/xyna/xmomrepository_adjust_revision_history.sh ${XMOMREPOSITORY}
-mkdir ${XYNA_PATH}/../git
+mkdir /opt/xyna/xyna_001/git
 EOF
 
 ENV SYNC_CONTAINER_LIFECYCLE_TO_FACTORY=true


### PR DESCRIPTION
* xynadev and xynafactory images contain an empty directory for git repositories at the default location
* the docker compose file mounts a persistent volume at the default location
* see https://github.com/Xyna-Factory/xyna-factory/issues/2288